### PR TITLE
Allow non-NTLM resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.idea
+coverage
+test/ntlm-options.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: false
+language: node_js
+node_js:
+  - "stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3
+
+* Allow requests to non-NTLM resources
+
 # 0.1.1
 
 * Bugfix to allow type1 message auth

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ ntlm.post(opts, json, function(err, response) {
 * options.domain is in use by request. Use ntlm_domain instead
 * ability to set custom headers
 * ability to use http and not only https
+* gracefully complete the request if the server doesn't actually require NTLM.
+  Fail only if `options.ntlm.strict` is set to `true` (default=`false`).

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-var async = require('async');
+var _       = require('lodash');
+var async   = require('async');
 var request = require('request');
-var ntlm = require('./lib/ntlm');
-var KeepAlive = require('agentkeepalive');
-var _ = require('lodash');
+var ntlm    = require('./lib/ntlm');
 
 var makeRequest = function(method, options, params, callback) {
-  
+
+  var KeepAlive = require('agentkeepalive');
   if (options.url.toLowerCase().indexOf('https://') === 0) {
     KeepAlive = KeepAlive.HttpsAgent;
   }
@@ -14,7 +14,10 @@ var makeRequest = function(method, options, params, callback) {
 
   if (!options.workstation) options.workstation = '';
   if (!options.ntlm_domain) options.ntlm_domain = '';
-  if (!options.headers) options.headers = {};
+  if (!options.headers    ) options.headers     = {};
+
+  options.ntlm = options.ntlm || {};
+  options.ntlm.strict = Boolean(options.ntlm.strict);
 
   function startAuth($) {
     var type1msg = ntlm.createType1Message(options);
@@ -28,8 +31,11 @@ var makeRequest = function(method, options, params, callback) {
   }
 
   function requestComplete(res, body, $) {
-    if (!res.headers['www-authenticate'])
-      return $(new Error('www-authenticate not found on response of second request'));
+    if (!res.headers['www-authenticate']) {
+      return options.ntlm.strict
+          ? $(new Error('www-authenticate not found on response of second request'))
+          : $(null, res, body);
+    }
 
     var type2msg = ntlm.parseType2Message(res.headers['www-authenticate']);
     var type3msg = ntlm.createType3Message(type2msg, options);
@@ -52,7 +58,7 @@ var makeRequest = function(method, options, params, callback) {
   async.waterfall([startAuth, requestComplete], callback);
 };
 
-exports.get = _.partial(makeRequest, 'get');
-exports.post = _.partial(makeRequest, 'post');
-exports.put = _.partial(makeRequest, 'put');
-exports.delete = _.partial(makeRequest, 'delete');
+exports.get   = _.partial(makeRequest, 'get');
+exports.post  = _.partial(makeRequest, 'post');
+exports.put   = _.partial(makeRequest, 'put');
+exports.delete= _.partial(makeRequest, 'delete');

--- a/package.json
+++ b/package.json
@@ -1,24 +1,53 @@
 {
   "name": "request-ntlm-continued",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "NTLM auth for NodeJS - continued from Colyn Brown's project",
   "main": "index.js",
   "repository": "https://github.com/FrankyBoy/request-ntlm",
-  "contributors": [{
-    "name": "Colyn Brown",
-    "email": "clbrown@godaddy.com"
-  },{
-    "name": "Immanuel Hayden",
-    "email": "immanuel.hayden@gmail.com"
-  },{
-    "name": "Brett Profitt",
-    "email": "brett.profitt@gmail.com"
-  }],
+  "scripts": {
+    "test": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+  },
+  "contributors": [
+    {
+      "name": "Colyn Brown",
+      "email": "clbrown@godaddy.com"
+    },
+    {
+      "name": "Immanuel Hayden",
+      "email": "immanuel.hayden@gmail.com"
+    },
+    {
+      "name": "Brett Profitt",
+      "email": "brett.profitt@gmail.com"
+    },
+    {
+      "name": "Andreas Pizsa",
+      "url": "https://github.com/AndreasPizsa"
+    }
+  ],
   "license": "ISC",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
     "async": "^0.7.0",
     "lodash": "^2.4.1",
     "request": "^2.34.0"
-  }
+  },
+  "devDependencies": {
+    "coveralls": "*",
+    "istanbul": "*",
+    "mocha": "*",
+    "mocha-lcov-reporter": "*",
+    "should": "*"
+  },
+  "keywords" : [
+    "ntlm",
+    "authentication",
+    "auth",
+    "login",
+    "windows",
+    "microsoft",
+    "request",
+    "http",
+    "https"
+  ]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ describe('request-ntlm-continued', function(){
 
     this.timeout(10000);
 
-    var executeRequestAgainsNtlmServer = simpleGetRequest;
+    var executeRequestAgainsNtlmServer = undefined;
     try {
         var options = require(__dirname + '/ntlm-options');
         executeRequestAgainsNtlmServer = simpleGetRequest(options);

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,56 @@
+
+var should = require('should');
+var request = require('../index.js');
+
+describe('request-ntlm-continued', function(){
+
+    function simpleGetRequest(options) {
+        return function(callback) {
+            request.get(options, undefined, function (err, res, body) {
+                should.not.exist(err);
+                should.exist(res);
+                should.exist(body);
+                callback();
+            });
+        }
+    }
+
+    this.timeout(10000);
+
+    var executeRequestAgainsNtlmServer = simpleGetRequest;
+    try {
+        var options = require(__dirname + '/ntlm-options');
+        executeRequestAgainsNtlmServer = simpleGetRequest(options);
+    }
+    catch(err) {
+    }
+
+    it('successfully execute a request against an NTLM server', executeRequestAgainsNtlmServer);
+
+    describe("non-NTLM requests", function(){
+
+        var options;
+        beforeEach(function(){
+            options = {
+                username    : 'username',
+                password    : 'password',
+                ntlm_domain : 'yourdomain',
+                workstation : 'workstation',
+                url         : 'https://www.google.com/search?q=ntlm',
+                strictSSL   : false
+            };
+        });
+
+        it('successfully execute a request against a non-NTLM server', function(done){
+            simpleGetRequest(options)(done);
+        });
+
+        it('fails when requesting non-NTLM resource with `options.ntlm.strict`', function(done){
+            options.ntlm = { strict:true };
+            request.get(options, undefined, function (err) {
+                should.exist(err);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hi @FrankyBoy !

I came across an issue when I was writing test cases for a project where our production system requires NTLM, and our test system does not.

The standard behavior when requesting an unprotected resource with, say, Basic Auth credentials is that the server just ignores the credentials and responds normally without authentication.

The current implementation of `request-ntlm` though _requires_ the remote server to respond with an NTLM handshake message, and fails with an error if it doesn't. 

This PR implements the standard behavior: the request executes normally - without further NTLM handshake - if the server doesn't respond with an NTLM message (which essentially means it's probably not an NTLM server). 

For situations where NTLM authentication is strictly required, a new flag `ntlm.strict` can be set to `true`, which enables the "old" behavior.

I also added test cases, updated the README, CHANGELOG and `package.json`, so that it should be easy to do a successful `npm update`  after a merge, hoping to use only very little our time :)

Thank you :)
