### PR TITLE
Make request.pipe() accessible for streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ ntlm.post(opts, json, function(err, response) {
 });
 ```
 
+Requests can also be streamed:
+
+```javascript
+ntlm.get(opts, json, null, fs.createWriteStream('example.pdf'));
+```
+
 ## Changes from original:
 
 * don't assume the post body is an object and should be made into json
@@ -36,3 +42,4 @@ ntlm.post(opts, json, function(err, response) {
 * ability to use http and not only https
 * gracefully complete the request if the server doesn't actually require NTLM.
   Fail only if `options.ntlm.strict` is set to `true` (default=`false`).
+* implement streaming

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var async   = require('async');
 var request = require('request');
 var ntlm    = require('./lib/ntlm');
 
-var makeRequest = function(method, options, params, callback) {
+var makeRequest = function(method, options, params, callback, pipeTarget) {
 
   var KeepAlive = require('agentkeepalive');
   if (options.url.toLowerCase().indexOf('https://') === 0) {
@@ -52,7 +52,11 @@ var makeRequest = function(method, options, params, callback) {
     else
       options.json = params;
 
-    request(options, $);
+    if (pipeTarget) {
+      request(options, $).pipe(pipeTarget);
+    } else {
+      request(options, $);
+    }
   }
 
   async.waterfall([startAuth, requestComplete], callback);


### PR DESCRIPTION
I needed to download some files from an NTLM server and because of their size, streaming was the only practical solution.

I have hacked in support for this so I'm passing it along in case you want to include it.  Feel free to reimplement in a different way if you have any better ideas how to achieve the same thing.