### PR TITLE
Remove lowercase connection and authorization on options.header

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ var makeRequest = function(method, options, params, callback, pipeTarget) {
   function startAuth($) {
     var type1msg = ntlm.createType1Message(options);
     options.method = method;
+    delete options.headers.connection;
+    delete options.headers.authorization;
     _.extend(options.headers, {
       'Connection': 'keep-alive',
       'Authorization': type1msg

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,8 @@ describe('request-ntlm-continued', function(){
                 should.not.exist(err);
                 should.exist(res);
                 should.exist(body);
+                should.not.exist(options.headers.connection);
+                should.not.exist(options.headers.authorization);
                 callback();
             });
         }
@@ -51,6 +53,13 @@ describe('request-ntlm-continued', function(){
                 should.exist(err);
                 done();
             });
+        });
+
+        it('removes lowercase connection and authorization from options.header', function(done){
+            options.headers = {};
+            options.headers.connection = "close";
+            options.headers.authorization = "some auth";
+            simpleGetRequest(options)(done);
         });
     });
 });


### PR DESCRIPTION
Hi there!
I got a problem with [nock](https://github.com/node-nock/nock) complaining about duplicate headers when I proxy requests with ntlm.post and mocking the ntlm url.

The _.extend of Connection and Authorization replaces headers in options if they are same casing but in my case I grab all headers I get from an external request and put them in options.headers and they are lowercase.

So in this PR I just delete the lowercase headers.

Very fresh on node so please let me know if I can change something (or if you want to throw this in the trash). 